### PR TITLE
Add simple greetings package with tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
 # Test-v2-public
+
+This repository contains a simple greetings package.
+
+## Usage
+
+Run the command-line interface to print a greeting:
+
+```
+python -m greetings Alice
+```
+
+## Development
+
+Run the test suite:
+
+```
+python -m unittest
+```

--- a/greetings/__init__.py
+++ b/greetings/__init__.py
@@ -1,0 +1,5 @@
+"""Simple greetings package."""
+
+from .greeter import greet
+
+__all__ = ["greet"]

--- a/greetings/__main__.py
+++ b/greetings/__main__.py
@@ -1,0 +1,15 @@
+"""Command-line interface for greetings."""
+
+from .greeter import greet
+import argparse
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Greet someone")
+    parser.add_argument("name", nargs="?", default="World", help="Name to greet")
+    args = parser.parse_args()
+    print(greet(args.name))
+
+
+if __name__ == "__main__":
+    main()

--- a/greetings/greeter.py
+++ b/greetings/greeter.py
@@ -1,0 +1,13 @@
+"""Greeting utilities."""
+
+
+def greet(name: str = "World") -> str:
+    """Return a personalized greeting message.
+
+    Args:
+        name: Name of the person to greet. Defaults to "World".
+
+    Returns:
+        A greeting string.
+    """
+    return f"Hello, {name}!"

--- a/tests/test_greeter.py
+++ b/tests/test_greeter.py
@@ -1,0 +1,15 @@
+import unittest
+
+from greetings.greeter import greet
+
+
+class GreetTests(unittest.TestCase):
+    def test_default_greeting(self) -> None:
+        self.assertEqual(greet(), "Hello, World!")
+
+    def test_custom_name(self) -> None:
+        self.assertEqual(greet("Alice"), "Hello, Alice!")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- create simple greetings package with CLI
- add tests for default and custom greetings
- document usage and testing in README
- ignore Python cache files

## Testing
- `python -m unittest discover -s tests`


------
https://chatgpt.com/codex/tasks/task_e_68a7e03f274c832992187b777a6089d5